### PR TITLE
fix(lexer): preserve escape sequences

### DIFF
--- a/examples/query_rules.cnf
+++ b/examples/query_rules.cnf
@@ -1,0 +1,28 @@
+mysql_query_rules:
+(
+  {
+    rule_id               = 50;
+    schemaname            = "web_production";
+    active                = 1;
+    apply                 = 0;
+    match_pattern         = "\/\*\s*dde='([^*]|\*[^\/]|)*\*\/\s*$";
+    re_modifiers          = "GLOBAL,CASELESS";
+  },
+  {
+    rule_id               = 51;
+    schemaname            = "web_production";
+    flagOUT               = 50;
+    active                = 1;
+    apply                 = 0;
+    match_pattern         = "\/\*\s*controller='([^*]|\*[^\/]|)*\*\/\s*$";
+    re_modifiers          = "GLOBAL,CASELESS";
+  },
+  {
+    rule_id               = 55;
+    schemaname            = "web_production";
+    flagOUT               = 50;
+    active                = 1;
+    apply                 = 0;
+    match_pattern         = ".*";
+  },
+)

--- a/lexer.go
+++ b/lexer.go
@@ -234,6 +234,8 @@ func (l *Lexer) readString() string {
 				result.WriteRune('\\')
 			case '"':
 				result.WriteRune('"')
+			case '/':
+				result.WriteRune('/')
 			case 'x':
 				// Hexadecimal escape \xNN
 				l.advance()
@@ -259,6 +261,9 @@ func (l *Lexer) readString() string {
 
 				continue
 			default:
+				// For unknown escape sequences, preserve the backslash
+				// This is important for regex patterns and other use cases
+				result.WriteRune('\\')
 				result.WriteRune(l.current)
 			}
 		} else {

--- a/libconfig_test.go
+++ b/libconfig_test.go
@@ -1937,3 +1937,22 @@ func TestRealWorldConfig(t *testing.T) {
 		t.Errorf("Expected CPU threshold 80.0, got %f", cpuThreshold)
 	}
 }
+
+func TestEscapeSequenceInRegex(t *testing.T) {
+	input := `test_pattern = "\/\*\s*dde='([^*]|\*[^\/]|)*\*\/\s*$";`
+
+	config, err := ParseString(input)
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	pattern, err := config.LookupString("test_pattern")
+	if err != nil {
+		t.Fatalf("Failed to lookup test_pattern: %v", err)
+	}
+
+	expected := "/\\*\\s*dde='([^*]|\\*[^/]|)*\\*/\\s*$"
+	if pattern != expected {
+		t.Errorf("Expected %q, got %q", expected, pattern)
+	}
+}


### PR DESCRIPTION
For example, in regex patterns.

Previously, the string lexer was incorrectly stripping backslashes from unrecognized escape sequences, causing regex patterns like `\/\*\s*dde='([^*]|\*[^\/]|)*\*\/\s*$` to be parsed as `/*s*dde='([^*]|*[^/]|)**/s*$` with critical escapes lost.

Changes:
- Add explicit handling for forward slash escapes (`\/` → `/`)
- Preserve backslashes for unknown escape sequences (e.g., `\s`, `\*`)
- Add test case to prevent regression
